### PR TITLE
Add parsing for `distinct` keyword

### DIFF
--- a/core/ast.cpp
+++ b/core/ast.cpp
@@ -38,6 +38,7 @@ constexpr inline const char8* const NODE_TYPE_NAMES[] = {
 	"UOpEval",
 	"UOpTry",
 	"UOpDefer",
+	"UOpDistinct",
 	"UOpAddr",
 	"UOpDeref",
 	"UOpBitNot",

--- a/core/identifier_pool.cpp
+++ b/core/identifier_pool.cpp
@@ -33,6 +33,7 @@ static constexpr AttachmentRange<char8, Token> KEYWORDS[] = {
 	range::from_literal_string("return",  Token::KwdReturn),
 	range::from_literal_string("leave",  Token::KwdLeave),
 	range::from_literal_string("yield",  Token::KwdYield),
+	range::from_literal_string("distinct", Token::KwdDistinct)
 };
 
 struct IdentifierPool

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -55,6 +55,13 @@ struct RawLexeme
 	RawLexeme(Token token, f64 value) noexcept : token{ token }, float_value{ value } {}
 };
 
+// Operator Description Tuple. Consists of:
+//  - `AstTag` with the node type
+//  - `AstFlag` with the node flags
+//  - `u8` precedence (low to high)
+//  - `u8` whether it's right-associative
+//  - `u8` is_binary whether it's a binary operator
+//         (or unary, no ternary operators anywhere)
 struct OperatorDesc
 {
 	AstTag node_type;
@@ -134,11 +141,13 @@ static constexpr char8 BUILTIN_NAMES[][8] = {
 	{ 't', 'b', '_', 'c', 'o', 'm', 'p', 'l'},
 };
 
+
 static constexpr OperatorDesc UNARY_OPERATOR_DESCS[] = {
 	{ AstTag::INVALID,            AstFlag::EMPTY,      10, false, true  }, // ( - Opening Parenthesis
 	{ AstTag::UOpEval,            AstFlag::EMPTY,       8, false, false }, // eval
 	{ AstTag::UOpTry,             AstFlag::EMPTY,       8, false, false }, // try
 	{ AstTag::UOpDefer,           AstFlag::EMPTY,       8, false, false }, // defer
+	{ AstTag::UOpDistinct,        AstFlag::EMPTY,       2, false, false }, // distinct
 	{ AstTag::UOpAddr,            AstFlag::EMPTY,       2, false, false }, // $
 	{ AstTag::UOpBitNot,          AstFlag::EMPTY,       2, false, false }, // ~
 	{ AstTag::UOpLogNot,          AstFlag::EMPTY,       2, false, false }, // !

--- a/core/pass_data.hpp
+++ b/core/pass_data.hpp
@@ -96,6 +96,7 @@ enum class Token : u8
 		KwdEval,              // eval
 		KwdTry,               // try
 		KwdDefer,             // defer
+		KwdDistinct,          // distinct
 		UOpAddr,              // $
 		UOpNot,               // ~
 		UOpLogNot,            // !
@@ -338,6 +339,7 @@ enum class AstTag : u8
 	UOpEval,
 	UOpTry,
 	UOpDefer,
+	UOpDistinct,
 	UOpAddr,
 	UOpDeref,
 	UOpBitNot,

--- a/core/token.cpp
+++ b/core/token.cpp
@@ -38,6 +38,7 @@ static constexpr const char8* const TOKEN_NAMES[] = {
 	"eval",
 	"try",
 	"defer",
+	"distinct",
 	"$",
 	"~",
 	"!",

--- a/sample/source.evl
+++ b/sample/source.evl
@@ -14,6 +14,8 @@ let the_value = 1
 
 let return_value = the_value
 
+(-)
+
 let TypeIdentity = func(t : type) -> type = t
 
 // let x: TypeIdentity(s32) = 1


### PR DESCRIPTION
Implemented parsing tokens and enums for the `distinct` keyword  (see issue #2 )